### PR TITLE
Add support for Delimiter on S3ListObjectStream

### DIFF
--- a/lib/stream/s3ListObjectStream.js
+++ b/lib/stream/s3ListObjectStream.js
@@ -128,6 +128,7 @@ S3ListObjectStream.prototype.listObjectsPage = function (options, callback) {
  *   request. Defaults to 1000.
  * @param {String} [options.prefix] If present, only list objects with keys that
  *   match the prefix.
+ * @param {String} [options.delimiter] If present, used to group keys.
  * @param {Function} callback Invoked after this listing is processed.
  */
 S3ListObjectStream.prototype.listObjects = function (options, callback) {

--- a/lib/stream/s3ListObjectStream.js
+++ b/lib/stream/s3ListObjectStream.js
@@ -26,6 +26,8 @@ var async = require('async');
  *   maxKeys: 1000,
  *   // Optional. If present, only list objects with keys matching the prefix.
  *   prefix: 'examplePrefix'
+ *   // Optional. If present, use to group keys.
+ *   delimiter: '/'
  * }
  *
  * Pipe out standard response objects from the S3 listObjects API, with the
@@ -77,6 +79,7 @@ util.inherits(S3ListObjectStream, Transform);
  *   starting from the marker.
  * @param {Number} [options.maxKeys] Maximum number of keys to return per
  *   request. Defaults to 1000.
+ * @param {String} [options.delimiter] A character you use to group keys.
  * @param {Function} callback - Callback of the form
     function (error, nextMarker, Object[]).
  */
@@ -85,7 +88,8 @@ S3ListObjectStream.prototype.listObjectsPage = function (options, callback) {
     Bucket: options.bucket,
     Marker: options.marker,
     MaxKeys: options.maxKeys,
-    Prefix: options.prefix
+    Prefix: options.prefix,
+    Delimiter: options.delimiter
   };
 
   // S3 operations have a small but significant error rate.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "s3",
     "stream"
   ],
-  "version": "0.8.1",
+  "version": "0.7.0",
   "homepage": "https://github.com/exratione/s3-object-streams",
   "author": "Reason <reason@exratione.com>",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "s3",
     "stream"
   ],
-  "version": "0.8.0",
+  "version": "0.8.1",
   "homepage": "https://github.com/exratione/s3-object-streams",
   "author": "Reason <reason@exratione.com>",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "s3",
     "stream"
   ],
-  "version": "0.7.0",
+  "version": "0.8.0",
   "homepage": "https://github.com/exratione/s3-object-streams",
   "author": "Reason <reason@exratione.com>",
   "engines": {

--- a/test/lib/stream/s3ListObjectStream.spec.js
+++ b/test/lib/stream/s3ListObjectStream.spec.js
@@ -84,7 +84,8 @@ describe('lib/stream/s3ListObjectStream', function () {
         bucket: 'bucket',
         prefix: 'prefix',
         marker: 'marker',
-        maxKeys: 50
+        maxKeys: 50,
+        delimiter: 'delimiter'
       };
     });
 
@@ -96,7 +97,8 @@ describe('lib/stream/s3ListObjectStream', function () {
             Bucket: options.bucket,
             Marker: options.marker,
             MaxKeys: options.maxKeys,
-            Prefix: options.prefix
+            Prefix: options.prefix,
+            Delimiter: options.delimiter
           },
           sinon.match.func
         );
@@ -126,7 +128,8 @@ describe('lib/stream/s3ListObjectStream', function () {
       options = {
         s3Client: s3Client,
         bucket: 'bucket',
-        prefix: 'prefix'
+        prefix: 'prefix',
+        delimiter: 'delimiter'
       }
     });
 
@@ -141,13 +144,15 @@ describe('lib/stream/s3ListObjectStream', function () {
           Bucket: options.bucket,
           Marker: undefined,
           MaxKeys: 1000,
-          Prefix: options.prefix
+          Prefix: options.prefix,
+          Delimiter: options.delimiter
         });
         expect(s3Client.listObjects.getCall(1).args[0]).to.eql({
           Bucket: options.bucket,
           Marker: listObjectResponse1.Contents[1].Key,
           MaxKeys: 1000,
-          Prefix: options.prefix
+          Prefix: options.prefix,
+          Delimiter: options.delimiter
         });
 
         expect(s3ListObjectStream.push.getCall(0).args).to.eql([


### PR DESCRIPTION
Adding the optional `options.delimiter` parameter unlocks support for listing of keys hierarchically using a `Prefix` and `Delimiter` - http://docs.aws.amazon.com/AmazonS3/latest/dev/ListingKeysHierarchy.html