### PR TITLE
add FetchOwner support to v2 params and set to true by default to mat…

### DIFF
--- a/lib/stream/s3ConcurrentListObjectStream.js
+++ b/lib/stream/s3ConcurrentListObjectStream.js
@@ -120,6 +120,7 @@ S3ConcurrentListObjectStream.prototype.sendToQueue = function (options) {
  *   requests for object listing. Defaults to '/'.
  * @param {String} [options.prefix] If set only return keys beginning with
  *   the prefix value.
+ * @param {String} [options.owner] enable v2 FetchOwner flag
  * @param {String} [options.continuationToken] If set the list only a paged set
  *   of keys, with the token showing the start point.
  * @param {Number} [options.maxKeys] Maximum number of keys to return per
@@ -136,6 +137,7 @@ S3ConcurrentListObjectStream.prototype.listDirectoryPage = function (
     Delimiter: options.delimiter,
     ContinuationToken: options.continuationToken,
     MaxKeys: options.maxKeys,
+    FetchOwner: options.owner,
     Prefix: options.prefix
   };
 
@@ -261,6 +263,7 @@ S3ConcurrentListObjectStream.prototype.listDirectoryAndRecuse = function (
  *   requests for object listing. Defaults to '/'.
  * @param {Number} [options.maxKeys] Maximum number of keys to return per
  *   request. Defaults to 1000.
+ * @param {String} [options.owner] If present, show owner struct of object 
  * @param {String} [options.prefix] If present, only list objects with keys that
  *   match the prefix.
  * @param {String} encoding Irrelevant since this is an object stream.
@@ -281,7 +284,8 @@ S3ConcurrentListObjectStream.prototype.processIncomingObject = function (
   }
 
   options.delimiter = options.delimiter || '/';
-
+  // default to fetching the owner
+  options.owner = options.owner || true;
   // Reset the global state for the next item.
   //
   // Since incoming items are processed in order, the next not starting until


### PR DESCRIPTION
this change turns on fetchOwner attribute by default for the concurrent listObjectsV2 function. I did not test it with it off by default to see if toggling it one way or the other works since on by default seems reasonable. 